### PR TITLE
Add Sequelize models for new tables

### DIFF
--- a/ade-backend/src/models/Check.js
+++ b/ade-backend/src/models/Check.js
@@ -1,0 +1,21 @@
+module.exports = (sequelize, DataTypes) => {
+  const Check = sequelize.define('Check', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    diagnosis_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    doctor_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    answer: DataTypes.TEXT
+  }, {
+    tableName: 'checks',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Check.associate = models => {
+    Check.belongsTo(models.Diagnosis, { foreignKey: 'diagnosis_id' });
+    Check.belongsTo(models.Doctor, { foreignKey: 'doctor_id' });
+  };
+
+  return Check;
+};

--- a/ade-backend/src/models/Consultation.js
+++ b/ade-backend/src/models/Consultation.js
@@ -1,0 +1,29 @@
+module.exports = (sequelize, DataTypes) => {
+  const Consultation = sequelize.define('Consultation', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    patient_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    doctor_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    diagnosis_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: true },
+    scheduled_at: { type: DataTypes.DATE, allowNull: false },
+    status: {
+      type: DataTypes.ENUM('planned','done','cancelled'),
+      allowNull: false,
+      defaultValue: 'planned'
+    },
+    mode: { type: DataTypes.ENUM('video','audio'), allowNull: false }
+  }, {
+    tableName: 'consultations',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Consultation.associate = models => {
+    Consultation.belongsTo(models.Patient, { foreignKey: 'patient_id' });
+    Consultation.belongsTo(models.Doctor, { foreignKey: 'doctor_id' });
+    Consultation.belongsTo(models.Diagnosis, { foreignKey: 'diagnosis_id' });
+  };
+
+  return Consultation;
+};

--- a/ade-backend/src/models/Delivery.js
+++ b/ade-backend/src/models/Delivery.js
@@ -1,0 +1,23 @@
+module.exports = (sequelize, DataTypes) => {
+  const Delivery = sequelize.define('Delivery', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    order_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, unique: true },
+    courier_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    status: { type: DataTypes.ENUM('assigned','picked','delivered'), allowNull: false, defaultValue: 'assigned' },
+    picked_at: DataTypes.DATE,
+    delivered_at: DataTypes.DATE
+  }, {
+    tableName: 'deliveries',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Delivery.associate = models => {
+    Delivery.belongsTo(models.Order, { foreignKey: 'order_id' });
+    Delivery.belongsTo(models.Courier, { foreignKey: 'courier_id' });
+  };
+
+  return Delivery;
+};

--- a/ade-backend/src/models/Order.js
+++ b/ade-backend/src/models/Order.js
@@ -1,0 +1,22 @@
+module.exports = (sequelize, DataTypes) => {
+  const Order = sequelize.define('Order', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    patient_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    pharmacy_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    status: { type: DataTypes.ENUM('pending','paid','preparing','shipped','delivered'), allowNull: false, defaultValue: 'pending' },
+    total_amount: { type: DataTypes.DECIMAL(10,2), allowNull: false }
+  }, {
+    tableName: 'orders',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Order.associate = models => {
+    Order.belongsTo(models.Patient, { foreignKey: 'patient_id' });
+    Order.belongsTo(models.Pharmacy, { foreignKey: 'pharmacy_id' });
+  };
+
+  return Order;
+};

--- a/ade-backend/src/models/OrderItem.js
+++ b/ade-backend/src/models/OrderItem.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const OrderItem = sequelize.define('OrderItem', {
+    order_id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true },
+    product_id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true },
+    qty: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    unit_price: { type: DataTypes.DECIMAL(10,2), allowNull: false }
+  }, {
+    tableName: 'order_items',
+    underscored: true,
+    timestamps: false
+  });
+
+  return OrderItem;
+};

--- a/ade-backend/src/models/PharmacyStock.js
+++ b/ade-backend/src/models/PharmacyStock.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const PharmacyStock = sequelize.define('PharmacyStock', {
+    pharmacy_id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true },
+    product_id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true },
+    quantity: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    price: { type: DataTypes.DECIMAL(10,2), allowNull: false }
+  }, {
+    tableName: 'pharmacy_stock',
+    underscored: true,
+    timestamps: false
+  });
+
+  return PharmacyStock;
+};

--- a/ade-backend/src/models/Prescription.js
+++ b/ade-backend/src/models/Prescription.js
@@ -1,0 +1,19 @@
+module.exports = (sequelize, DataTypes) => {
+  const Prescription = sequelize.define('Prescription', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    consultation_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    pdf_url: { type: DataTypes.STRING(255), allowNull: false }
+  }, {
+    tableName: 'prescriptions',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Prescription.associate = models => {
+    Prescription.belongsTo(models.Consultation, { foreignKey: 'consultation_id' });
+  };
+
+  return Prescription;
+};

--- a/ade-backend/src/models/Product.js
+++ b/ade-backend/src/models/Product.js
@@ -1,0 +1,15 @@
+module.exports = (sequelize, DataTypes) => {
+  const Product = sequelize.define('Product', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    name: { type: DataTypes.STRING(255), allowNull: false },
+    form: DataTypes.STRING(100),
+    dosage: DataTypes.STRING(100),
+    atc_code: DataTypes.STRING(50)
+  }, {
+    tableName: 'products',
+    underscored: true,
+    timestamps: false
+  });
+
+  return Product;
+};

--- a/ade-backend/src/models/index.js
+++ b/ade-backend/src/models/index.js
@@ -45,6 +45,14 @@ db.Courier     = require('./Courier')(sequelize, DataTypes);
 db.Patient     = require('./patient')(sequelize, DataTypes);
 db.Diagnosis   = require('./Diagnosis')(sequelize, DataTypes);
 db.DiseasesList = require('./DiseasesList')(sequelize, DataTypes);
+db.Consultation = require('./Consultation')(sequelize, DataTypes);
+db.Prescription = require('./Prescription')(sequelize, DataTypes);
+db.Product      = require('./Product')(sequelize, DataTypes);
+db.PharmacyStock = require('./PharmacyStock')(sequelize, DataTypes);
+db.Order        = require('./Order')(sequelize, DataTypes);
+db.OrderItem    = require('./OrderItem')(sequelize, DataTypes);
+db.Delivery     = require('./Delivery')(sequelize, DataTypes);
+db.Check        = require('./Check')(sequelize, DataTypes);
 
  // Mise en place des associations, si définies dans chaque modèle
  Object.keys(db).forEach(name => {


### PR DESCRIPTION
## Summary
- integrate tables from `Database Design.md`
- create Sequelize models for consultations, prescriptions, products and more
- register new models in `src/models/index.js`

## Testing
- `npm test` in `ade-backend` *(fails: Missing script)*
- `npm test` in `ade-frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c4b8e24388330b9fdb5717d9b7619