### PR TITLE
Fix pending check display on doctor dashboard

### DIFF
--- a/ade-frontend/src/api/checks.js
+++ b/ade-frontend/src/api/checks.js
@@ -2,3 +2,5 @@ import api from '../services/api';
 
 export const createCheck = (disease_id, symptoms, doctor_user_id) =>
   api.post('/checks', { disease_id, symptoms, doctor_user_id });
+
+export const getDoctorChecks = () => api.get('/doctors/me/checks');


### PR DESCRIPTION
## Summary
- add endpoint to list logged doctor's checks
- expose `getDoctorChecks` client helper
- load doctor checks in `DoctorDashboard`

## Testing
- `npm run lint` in `ade-frontend`

------
https://chatgpt.com/codex/tasks/task_e_684df6edc2c883308316097ce5420284