### PR TITLE
Fix account fetch with token

### DIFF
--- a/ade-frontend/src/pages/MonCompte.jsx
+++ b/ade-frontend/src/pages/MonCompte.jsx
@@ -1,24 +1,28 @@
 // src/pages/MonCompte.jsx
-import { useState, useEffect, } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
+import { AuthContext } from '../context/AuthContext';
 
 export default function MonCompte() {
+  const { token, logout } = useContext(AuthContext);
   const [user, setUser]   = useState(null);
   const [error, setError] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!token) return;
     api.get('/moncompte')
       .then(({ data }) => setUser(data))
       .catch(err => {
         console.error(err);
+        if (err.response?.status === 401) logout();
         setError('Impossible de charger vos informations.');
       });
-  }, []);
+  }, [token, logout]);
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
+    logout();
     navigate('/login');
   };
 


### PR DESCRIPTION
## Summary
- ensure `MonCompte` waits for a logged user token before fetching
- trigger logout if the token is invalid
- use context logout helper when signing out

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684efdf4f6408330a69f5be6599b9f62