### PR TITLE
Implement doctor response workflow

### DIFF
--- a/ade-backend/src/routes/checks.js
+++ b/ade-backend/src/routes/checks.js
@@ -36,4 +36,24 @@ router.post('/', auth, async (req, res) => {
   }
 });
 
+// PUT /checks/:id - update doctor's answer on a check
+router.put('/:id', auth, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const { answer } = req.body;
+    if (!id || !answer) {
+      return res.status(400).json({ error: 'id et answer requis' });
+    }
+    const [updated] = await Check.update(
+      { answer },
+      { where: { id, doctor_user_id: req.user.id } }
+    );
+    if (!updated) return res.status(404).json({ error: 'Check non trouvé' });
+    res.json({ message: 'Réponse enregistrée' });
+  } catch (err) {
+    console.error('update check error', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
 module.exports = router;

--- a/ade-frontend/src/api/checks.js
+++ b/ade-frontend/src/api/checks.js
@@ -4,3 +4,6 @@ export const createCheck = (disease_id, symptoms, doctor_user_id) =>
   api.post('/checks', { disease_id, symptoms, doctor_user_id });
 
 export const getDoctorChecks = () => api.get('/doctors/me/checks');
+
+export const updateCheckAnswer = (id, answer) =>
+  api.put(`/checks/${id}`, { answer });

--- a/ade-frontend/src/pages/DoctorDashboard.jsx
+++ b/ade-frontend/src/pages/DoctorDashboard.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useContext } from 'react';
 import { AuthContext } from '../context/AuthContext';
 import api from '../services/api';
 import { createDoctorProfile, toggleAvailability } from '../api/doctors';
-import { getDoctorChecks } from '../api/checks';
+import { getDoctorChecks, updateCheckAnswer } from '../api/checks';
 import './DoctorDashboard.css';
 
 export default function DoctorDashboard() {
@@ -14,6 +14,8 @@ export default function DoctorDashboard() {
   const [error, setError] = useState('');
   const [checks, setChecks] = useState([]);
   const [appointments] = useState([]);
+  const [answerId, setAnswerId] = useState(null);
+  const [answerText, setAnswerText] = useState('');
 
   const calcAge = dateStr => {
     if (!dateStr) return '';
@@ -77,10 +79,28 @@ export default function DoctorDashboard() {
   };
 
   const handleValidate = id => {
-    console.log('validate check', id);
+    setAnswerId(id);
+    setAnswerText('');
   };
-  const handleStartConsult = pid => {
-    console.log('start consult', pid);
+
+  const handleSubmitAnswer = async e => {
+    e.preventDefault();
+    if (!answerId) return;
+    try {
+      await updateCheckAnswer(answerId, answerText);
+      setChecks(cs => cs.filter(c => c.id !== answerId));
+    } catch (err) {
+      console.error('submit answer error', err);
+    } finally {
+      setAnswerId(null);
+      setAnswerText('');
+    }
+  };
+
+  const handleStartConsult = id => {
+    updateCheckAnswer(id, 'Please make an appointment')
+      .then(() => setChecks(cs => cs.filter(c => c.id !== id)))
+      .catch(err => console.error('consult request error', err));
   };
   const handleJoinAppointment = id => {
     console.log('join appointment', id);
@@ -157,10 +177,22 @@ export default function DoctorDashboard() {
                     <p>Symptômes : {check.symptoms}</p>
                     <p>Résultat : {check.diagnosis}</p>
                     <p>Notes : {check.notes}</p>
-                    <div className="card-actions">
-                      <button className="btn green" onClick={() => handleValidate(check.id)}>Valider</button>
-                      <button className="btn pink" onClick={() => handleStartConsult(check.patientId)}>Consultation/Diagnostic</button>
-                    </div>
+                    {answerId === check.id ? (
+                      <form onSubmit={handleSubmitAnswer} className="answer-form">
+                        <input
+                          value={answerText}
+                          onChange={e => setAnswerText(e.target.value)}
+                          placeholder="Votre réponse"
+                          required
+                        />
+                        <button type="submit" className="btn green">Submit</button>
+                      </form>
+                    ) : (
+                      <div className="card-actions">
+                        <button className="btn green" onClick={() => handleValidate(check.id)}>Valider</button>
+                        <button className="btn pink" onClick={() => handleStartConsult(check.id)}>Consultation/Diagnostic</button>
+                      </div>
+                    )}
                   </div>
                 ))}
               </div>
@@ -188,7 +220,7 @@ export default function DoctorDashboard() {
                   </div>
                 ))}
               </div>
-            )}
+              )}
           </div>
         </section>
     </div>

--- a/ade-frontend/src/pages/PatientDashboard.jsx
+++ b/ade-frontend/src/pages/PatientDashboard.jsx
@@ -59,8 +59,18 @@ export default function PatientDashboard() {
                   <p><strong>Résultat :</strong> {check.result}</p>
                   <p><strong>Réponse du médecin :</strong> {check.notes}</p>
                   <div className="card-actions">
-                    <button className="btn green" onClick={() => window.location = `/pharmacy/${check.id}`}>Pharmacie</button>
-                    <button className="btn pink" onClick={() => window.location = `/consult/${check.id}`}>Consultation/Diagnostic</button>
+                    {check.notes ? (
+                      check.notes === 'Please make an appointment' ? (
+                        <button className="btn pink" onClick={() => window.location = `/consult/${check.id}`}>Consultation/Diagnostic</button>
+                      ) : (
+                        <button className="btn green" onClick={() => window.location = `/pharmacy/${check.id}`}>Pharmacie</button>
+                      )
+                    ) : (
+                      <>
+                        <button className="btn green" onClick={() => window.location = `/pharmacy/${check.id}`}>Pharmacie</button>
+                        <button className="btn pink" onClick={() => window.location = `/consult/${check.id}`}>Consultation/Diagnostic</button>
+                      </>
+                    )}
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- save doctors' answers with a new PUT `/checks/:id` endpoint
- expose `updateCheckAnswer` API function on frontend
- allow doctors to answer checks or request consultation
- display only the relevant action button for patients based on doctor's answer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f10e80854833092bc6d1639831bf2