### PR TITLE
Fix patient dashboard check card actions

### DIFF
--- a/ade-frontend/src/pages/PatientDashboard.jsx
+++ b/ade-frontend/src/pages/PatientDashboard.jsx
@@ -59,17 +59,12 @@ export default function PatientDashboard() {
                   <p><strong>Résultat :</strong> {check.result}</p>
                   <p><strong>Réponse du médecin :</strong> {check.notes}</p>
                   <div className="card-actions">
-                    {check.notes ? (
+                    {check.notes && (
                       check.notes === 'Please make an appointment' ? (
                         <button className="btn pink" onClick={() => window.location = `/consult/${check.id}`}>Consultation/Diagnostic</button>
                       ) : (
                         <button className="btn green" onClick={() => window.location = `/pharmacy/${check.id}`}>Pharmacie</button>
                       )
-                    ) : (
-                      <>
-                        <button className="btn green" onClick={() => window.location = `/pharmacy/${check.id}`}>Pharmacie</button>
-                        <button className="btn pink" onClick={() => window.location = `/consult/${check.id}`}>Consultation/Diagnostic</button>
-                      </>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- hide pharmacy/consultation buttons if doctor hasn't answered yet

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f178cb92c833096a592905c33a825