### PR TITLE
Implement e‑Pharmacie feature

### DIFF
--- a/ade-backend/src/index.js
+++ b/ade-backend/src/index.js
@@ -22,6 +22,7 @@ const monCompteRouter  = require('./routes/moncompte')
 const userRouter = require('./routes/user'); // route GET /api/users
 const checksRouter = require('./routes/checks');
 const patientRouter = require('./routes/patient');
+const pharmacyRouter = require('./routes/pharmacy');
 
 
 // 5. App Express
@@ -49,6 +50,7 @@ app.use('/api/doctors', doctorRouter); // route GET /api/doctors
 app.use('/api/users', userRouter);
 app.use('/api/checks', checksRouter);
 app.use('/api', patientRouter);
+app.use('/api', pharmacyRouter);
 
 // 9. Connexion à la BDD, synchronisation des modèles, puis démarrage du serveur
 (async () => {

--- a/ade-frontend/src/App.jsx
+++ b/ade-frontend/src/App.jsx
@@ -13,6 +13,7 @@ import MonCompte from './pages/MonCompte';
 import Profile         from './pages/Profile.jsx';
 import DoctorDashboard from './pages/DoctorDashboard.jsx';
 import PatientDashboard from './pages/PatientDashboard.jsx';
+import Pharmacie from './pages/Pharmacie.jsx';
 import './index.css';
 
 export default function App() {
@@ -34,6 +35,7 @@ export default function App() {
           <Route path="/doctor"    element={<DoctorDashboard />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/patient" element={<PatientDashboard />} />
+          <Route path="/pharmacie" element={<Pharmacie />} />
 
           {/* Catch-all pour URL inconnues */}
           <Route

--- a/ade-frontend/src/pages/Pharmacie.jsx
+++ b/ade-frontend/src/pages/Pharmacie.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import api from '../services/api';
+
+export default function Pharmacie() {
+  const [pharmacies, setPharmacies] = useState([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setError('Géolocalisation non supportée');
+      setLoading(false);
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        fetchPharmacies(pos.coords.latitude, pos.coords.longitude);
+      },
+      () => {
+        setError('Impossible de récupérer votre position');
+        setLoading(false);
+      }
+    );
+  }, []);
+
+  const fetchPharmacies = async (lat, lon) => {
+    try {
+      const { data } = await api.get('/pharmacies/near', { params: { lat, lon } });
+      setPharmacies(data);
+    } catch {
+      setError('Erreur de chargement des pharmacies');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1>Pharmacies à proximité</h1>
+      {loading && <p>Chargement...</p>}
+      {error && <p>{error}</p>}
+      <div className="card-grid">
+        {pharmacies.map((p, i) => (
+          <div className="card" key={i}>
+            <h2>{p.name}</h2>
+            <p>{p.address}</p>
+            {p.is_on_call && <span>De garde</span>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate pharmacy router with a new `GET /pharmacies/near` endpoint calling Google Maps API
- mount the pharmacy routes in the Express server
- add a React page to show nearby pharmacies
- wire the new page in the router

## Testing
- `npm run lint` in `ade-frontend`
- `npm install` in both `ade-frontend` and `ade-backend`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854726869588330b4cc82f06d76c1fd