### PR TITLE
Add map-based pharmacy registration

### DIFF
--- a/ade-frontend/package-lock.json
+++ b/ade-frontend/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.9.0",
+        "leaflet": "^1.9.4",
         "lodash.debounce": "^4.0.8",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.5.3"
       },
       "devDependencies": {
@@ -1037,6 +1039,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2828,6 +2841,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3559,6 +3578,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/ade-frontend/package.json
+++ b/ade-frontend/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "axios": "^1.9.0",
+    "leaflet": "^1.9.4",
     "lodash.debounce": "^4.0.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.5.3"
   },
   "devDependencies": {

--- a/ade-frontend/src/components/MapPicker.jsx
+++ b/ade-frontend/src/components/MapPicker.jsx
@@ -1,0 +1,39 @@
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import { useState } from 'react';
+import 'leaflet/dist/leaflet.css';
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+// Fix default icon paths
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+});
+
+export default function MapPicker({ initialPosition = [0,0], onSelect }) {
+  const [position, setPosition] = useState(initialPosition);
+
+  function LocationMarker() {
+    useMapEvents({
+      click(e) {
+        const { lat, lng } = e.latlng;
+        setPosition([lat, lng]);
+        if (onSelect) onSelect(lat, lng);
+      }
+    });
+    return position ? <Marker position={position} /> : null;
+  }
+
+  return (
+    <MapContainer center={position} zoom={13} style={{ height: '300px', width: '100%' }}>
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="&copy; OpenStreetMap contributors"
+      />
+      <LocationMarker />
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add `leaflet` and `react-leaflet` dependencies
- create `MapPicker` component for selecting coordinates on a map
- integrate map picker into pharmacy registration and auto-fill fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854811361648330ba1e339f603a6c99