### PR TITLE
Add pharmacy dashboard

### DIFF
--- a/ade-backend/src/routes/pharmacy.js
+++ b/ade-backend/src/routes/pharmacy.js
@@ -35,6 +35,17 @@ router.post('/pharmacies', auth, async (req, res) => {
   } catch (e) { res.status(500).json({ error: 'Erreur création pharmacie' }); }
 });
 
+// GET /pharmacies/me – profil de la pharmacie connectée
+router.get('/pharmacies/me', auth, async (req, res) => {
+  try {
+    const pharmacy = await Pharmacy.findOne({ where: { user_id: req.user.id } });
+    if (!pharmacy) return res.status(404).json({ error: 'Pharmacie non trouvée' });
+    res.json(pharmacy);
+  } catch (err) {
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
 // PUT /pharmacies/me/oncall  { is_on_call: true|false }
 router.put('/pharmacies/me/oncall', auth, async (req, res) => {
   try {

--- a/ade-frontend/src/App.jsx
+++ b/ade-frontend/src/App.jsx
@@ -14,6 +14,7 @@ import Profile         from './pages/Profile.jsx';
 import DoctorDashboard from './pages/DoctorDashboard.jsx';
 import PatientDashboard from './pages/PatientDashboard.jsx';
 import Pharmacie from './pages/Pharmacie.jsx';
+import PharmacyDashboard from './pages/PharmacyDashboard.jsx';
 import './index.css';
 
 export default function App() {
@@ -35,6 +36,7 @@ export default function App() {
           <Route path="/doctor"    element={<DoctorDashboard />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/patient" element={<PatientDashboard />} />
+          <Route path="/pharmacy" element={<PharmacyDashboard />} />
           <Route path="/pharmacie" element={<Pharmacie />} />
 
           {/* Catch-all pour URL inconnues */}

--- a/ade-frontend/src/api/pharmacy.js
+++ b/ade-frontend/src/api/pharmacy.js
@@ -2,6 +2,7 @@
 import api from '../services/api';
 export const createPharmacyProfile = (payload) => api.post('/pharmacies', payload);
 export const toggleOnCall = (flag) => api.put('/pharmacies/me/oncall', { is_on_call: flag });
+export const getPharmacyProfile = () => api.get('/pharmacies/me');
 
 // Exemple d’usage dans PharmacyDashboard.jsx
 /*

--- a/ade-frontend/src/pages/PharmacyDashboard.css
+++ b/ade-frontend/src/pages/PharmacyDashboard.css
@@ -1,0 +1,166 @@
+#pharmacy-dashboard-container {
+  display: flex;
+  justify-content: space-between;
+  width: 80%;
+  height: 100vh;
+  margin: 0 auto;
+
+  h3 {
+  margin-block-start: 15px;
+  }
+}
+
+.pharmacy-dashboard-navbar {
+  height: 60px;
+  width: 100%;
+  background: white;
+  border-bottom: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  font-weight: bold;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.profile-sidebar {
+  width: 23%;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: white;
+}
+
+.profile-pic {
+  width: 50%;
+  aspect-ratio: 1/1;
+  background: #ddd;
+  border-radius: 10px;
+  margin-block-start: 25px;
+}
+
+#profile-name{
+    margin-block: 10px 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.status-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.status-indicator.green { background-color: var(--primary-color); }
+.status-indicator.red { background-color: var(--accent-color); }
+
+.btn.toggle {
+  margin-top: 10px;
+}
+
+#btn-edit, .btn-logout {
+  margin: 25px 0;
+}
+
+.btn-logout { background-color: var(--accent-color); color: white; }
+
+.sidebar-menu {
+  list-style: none;
+  padding: 20px;
+  margin: 0;
+  width: fit-content;
+  text-align: left;
+  font-size: 1.2em;
+
+  li {
+    margin-bottom: 25px;
+    border-bottom: 1px solid black;
+    cursor: pointer;
+    color: #333;
+    transition: transform .3s ease-in-out;
+  }
+}
+.sidebar-menu li:hover {
+  transform: scale(1.1);
+}
+
+.dashboard-content {
+  overflow-y: auto;
+  width: 75%;
+}
+
+.section{
+    margin-inline-start: 20px;
+}
+
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.card {
+  background: white;
+  padding: 15px;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+  width: fit-content !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.badge {
+  font-size: 0.75em;
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: white;
+}
+
+.badge.green { background-color: var(--primary-color); }
+
+.card-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.btn {
+  flex: 1;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.btn.green { background-color: #007f5f; color: white; }
+.btn.pink { background-color: #e91e63; color: white; }
+
+.pharma-form input {
+  display: block;
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 6px;
+}
+
+.error { color: red; }
+
+.empty-state {
+  padding: 20px;
+  text-align: center;
+  color: #666;
+  font-style: italic;
+}

--- a/ade-frontend/src/pages/PharmacyDashboard.jsx
+++ b/ade-frontend/src/pages/PharmacyDashboard.jsx
@@ -1,0 +1,114 @@
+import { useState, useEffect, useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import api from '../services/api';
+import { createPharmacyProfile, toggleOnCall } from '../api/pharmacy';
+import './PharmacyDashboard.css';
+
+export default function PharmacyDashboard() {
+  const { token, logout } = useContext(AuthContext);
+  const [pharmacy, setPharmacy] = useState(null);
+  const [user, setUser] = useState(null);
+  const [form, setForm] = useState({ name: '', address: '' });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    const fetchData = async () => {
+      try {
+        const { data } = await api.get('/moncompte');
+        setUser(data);
+      } catch (err) {
+        console.error('Pharmacy dashboard user fetch error', err);
+        if (err.response?.status === 401) logout();
+      }
+      try {
+        const { data } = await api.get('/pharmacies/me');
+        setPharmacy(data);
+      } catch (err) {
+        if (err.response?.status === 404) {
+          setPharmacy(null);
+        } else {
+          console.error('Pharmacy dashboard fetch error', err);
+          if (err.response?.status === 401) logout();
+        }
+      }
+    };
+    fetchData();
+  }, [token, logout]);
+
+  const handleChange = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const handleCreate = async e => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const { data } = await createPharmacyProfile(form);
+      setPharmacy(data);
+    } catch (err) {
+      setError(err.response?.data?.error || 'Erreur création pharmacie');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleToggleOnCall = async () => {
+    if (!pharmacy) return;
+    const newStatus = !pharmacy.is_on_call;
+    try {
+      await toggleOnCall(newStatus);
+      setPharmacy(p => ({ ...p, is_on_call: newStatus }));
+    } catch (err) {
+      console.error('toggle on call error', err);
+    }
+  };
+
+  if (!token) return <p>Veuillez vous connecter.</p>;
+
+  if (!pharmacy) {
+    return (
+      <div className="pharmacy-dashboard">
+        <form className="pharma-form" onSubmit={handleCreate}>
+          <h2>Compléter votre profil pharmacie</h2>
+          <input name="name" placeholder="Nom" value={form.name} onChange={handleChange} required />
+          <input name="address" placeholder="Adresse" value={form.address} onChange={handleChange} required />
+          <button disabled={loading}>{loading ? 'Enregistrement…' : 'Créer ma pharmacie'}</button>
+          {error && <p className="error">{error}</p>}
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container" id='pharmacy-dashboard-container'>
+        <aside className="profile-sidebar">
+          <div className="profile-pic" />
+          <h2 id='profile-name'>
+            {user ? `${user.first_name} ${user.last_name}` : ''}
+            <span
+              className={`status-indicator ${pharmacy.is_on_call ? 'green' : 'red'}`}
+            />
+          </h2>
+          <p>{pharmacy.address}</p>
+          <button className="btn toggle" onClick={handleToggleOnCall}>
+            {pharmacy.is_on_call ? 'Fin de garde' : 'Se déclarer en garde'}
+          </button>
+          <button id="btn-edit">Éditer mon profil</button>
+          <ul className="sidebar-menu">
+            <li>Commandes</li>
+            <li>Stock</li>
+            <li>Paramètres</li>
+          </ul>
+          <button className="btn-logout" onClick={logout}>Déconnexion</button>
+        </aside>
+
+        <section className="dashboard-content">
+          <div className="pharmacy-dashboard-navbar"><h2>Mon Tableau de Bord</h2></div>
+          <div className="section">
+            <h3>Mes commandes</h3>
+            <div className="empty-state">Aucune commande pour l'instant</div>
+          </div>
+        </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement pharmacy profile endpoint
- add pharmacy dashboard page and styles
- expose new dashboard route in frontend router
- extend pharmacy API client with profile getter

## Testing
- `npm run lint` in ade-frontend


------
https://chatgpt.com/codex/tasks/task_e_68553f89e6b08330b4abe9d16aff785f