### PR TITLE
Add interactive disease search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ Voir le fichier `.env.example` pour la liste complète et les clés attendues.
 
 ### Backend
 
-Modèles Sequelize : `User`, `DiseasesList`, `Search`, etc.
+Modèles Sequelize : `User`, `DiseasesList`, `Search` ainsi que `Question`, `QuestionOption`, `OptionImpact` et `UserQuestionResponse` pour la recherche interactive.
 
 Routes principales :
 
 - `/api/maladies?symptomes=...`
+- `/api/maladies/interactive` (POST) – recherche interactive avec questions
 - `/api/symptomes?q=...`
 - `/api/pharmacies?lat=...&lng=...&filter=...`
 - `/api/auth` & `/api/moncompte`

--- a/ade-backend/src/models/OptionImpact.js
+++ b/ade-backend/src/models/OptionImpact.js
@@ -1,0 +1,18 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const OptionImpact = sequelize.define('OptionImpact', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    option_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    disease_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    score_delta: { type: DataTypes.DECIMAL(4,2), allowNull: false }
+  }, {
+    tableName: 'option_impacts',
+    underscored: true,
+    timestamps: false
+  });
+  OptionImpact.associate = models => {
+    OptionImpact.belongsTo(models.QuestionOption, { foreignKey: 'option_id' });
+    OptionImpact.belongsTo(models.DiseasesList, { foreignKey: 'disease_id' });
+  };
+  return OptionImpact;
+};

--- a/ade-backend/src/models/Question.js
+++ b/ade-backend/src/models/Question.js
@@ -1,0 +1,21 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Question = sequelize.define('Question', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    question_text: { type: DataTypes.TEXT, allowNull: false },
+    question_type: {
+      type: DataTypes.ENUM('yes_no', 'multiple_choice', 'number', 'scale'),
+      defaultValue: 'yes_no'
+    },
+    trigger_symptom_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: true }
+  }, {
+    tableName: 'questions',
+    underscored: true,
+    timestamps: false
+  });
+  Question.associate = models => {
+    Question.belongsTo(models.Symptom, { foreignKey: 'trigger_symptom_id' });
+    Question.hasMany(models.QuestionOption, { foreignKey: 'question_id', as: 'options' });
+  };
+  return Question;
+};

--- a/ade-backend/src/models/QuestionOption.js
+++ b/ade-backend/src/models/QuestionOption.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const QuestionOption = sequelize.define('QuestionOption', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    question_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    option_label: { type: DataTypes.STRING(100), allowNull: false }
+  }, {
+    tableName: 'question_options',
+    underscored: true,
+    timestamps: false
+  });
+  QuestionOption.associate = models => {
+    QuestionOption.belongsTo(models.Question, { foreignKey: 'question_id' });
+    QuestionOption.hasMany(models.OptionImpact, { foreignKey: 'option_id', as: 'impacts' });
+  };
+  return QuestionOption;
+};

--- a/ade-backend/src/models/UserQuestionResponse.js
+++ b/ade-backend/src/models/UserQuestionResponse.js
@@ -1,0 +1,20 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const UserQuestionResponse = sequelize.define('UserQuestionResponse', {
+    id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+    user_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    question_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
+    selected_option_id: { type: DataTypes.INTEGER.UNSIGNED, allowNull: true },
+    created_at: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW }
+  }, {
+    tableName: 'user_question_responses',
+    underscored: true,
+    timestamps: false
+  });
+  UserQuestionResponse.associate = models => {
+    UserQuestionResponse.belongsTo(models.User, { foreignKey: 'user_id' });
+    UserQuestionResponse.belongsTo(models.Question, { foreignKey: 'question_id' });
+    UserQuestionResponse.belongsTo(models.QuestionOption, { foreignKey: 'selected_option_id' });
+  };
+  return UserQuestionResponse;
+};

--- a/ade-backend/src/models/index.js
+++ b/ade-backend/src/models/index.js
@@ -55,6 +55,10 @@ db.Symptom      = require('./Symptom')(sequelize, DataTypes);
 db.DiseaseSymptom = require('./DiseaseSymptom')(sequelize, DataTypes);
 db.Delivery     = require('./Delivery')(sequelize, DataTypes);
 db.Check        = require('./Check')(sequelize, DataTypes);
+db.Question     = require('./Question')(sequelize, DataTypes);
+db.QuestionOption = require('./QuestionOption')(sequelize, DataTypes);
+db.OptionImpact = require('./OptionImpact')(sequelize, DataTypes);
+db.UserQuestionResponse = require('./UserQuestionResponse')(sequelize, DataTypes);
 
  // Mise en place des associations, si définies dans chaque modèle
  Object.keys(db).forEach(name => {

--- a/ade-backend/src/routes/maladies.js
+++ b/ade-backend/src/routes/maladies.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { Op } = require('sequelize');
 const router = express.Router();
-const { DiseasesList, Symptom, DiseaseSymptom } = require('../models');
+const { DiseasesList, Symptom, DiseaseSymptom, Question, QuestionOption, OptionImpact } = require('../models');
 const { get: levenshtein } = require('fast-levenshtein');
 
 
@@ -114,6 +114,85 @@ router.get('/', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Erreur serveur lors de la recherche' });
+  }
+});
+
+// POST /maladies/interactive
+router.post('/interactive', async (req, res) => {
+  try {
+    const { symptoms = [], responses = [] } = req.body;
+
+    if (!Array.isArray(symptoms) || symptoms.length === 0) {
+      return res.status(400).json({ error: 'symptoms array required' });
+    }
+
+    const terms = symptoms.map(s => String(s).trim().toLowerCase()).filter(Boolean);
+    const searchQuery = terms.map(t => `+${t}*`).join(' ');
+
+    const matchedSymptoms = await Symptom.findAll({
+      where: Symptom.sequelize.literal(
+        `MATCH(name) AGAINST(${Symptom.sequelize.escape(searchQuery)} IN BOOLEAN MODE)`
+      ),
+      attributes: ['id']
+    });
+
+    const symptomIds = matchedSymptoms.map(s => s.id);
+    const linkRows = await DiseaseSymptom.findAll({
+      where: { symptom_id: { [Op.in]: symptomIds } }
+    });
+    const diseaseIds = [...new Set(linkRows.map(r => r.disease_id))];
+
+    const candidates = await DiseasesList.findAll({
+      where: { id: { [Op.in]: diseaseIds } },
+      include: [{ model: Symptom, attributes: ['name'], through: { attributes: [] } }]
+    });
+
+    const scored = candidates.map(item => {
+      const itemSyms = item.Symptoms.map(s => s.name.toLowerCase());
+      const matchCount = terms.reduce((acc, t) => acc + (itemSyms.includes(t) ? 1 : 0), 0);
+      const diffScore = 1 - Math.min(Math.abs(itemSyms.length - terms.length) / Math.max(itemSyms.length, terms.length), 1);
+      const spellTotal = terms.reduce((acc, term) => {
+        const best = itemSyms.reduce((max, sym) => Math.max(max, similarity(term, sym)), 0);
+        return acc + best;
+      }, 0);
+      const spellScore = terms.length ? spellTotal / terms.length : 0;
+      const countScore = terms.length ? (matchCount / terms.length) * diffScore : 0;
+      const baseScore = (0.7 * countScore + 0.3 * spellScore) * 5;
+      return { item, score: baseScore };
+    });
+
+    if (responses.length) {
+      const optIds = responses.map(r => r.optionId).filter(Boolean);
+      if (optIds.length) {
+        const impacts = await OptionImpact.findAll({ where: { option_id: { [Op.in]: optIds } } });
+        scored.forEach(s => {
+          const totalDelta = impacts
+            .filter(i => i.disease_id === s.item.id)
+            .reduce((acc, i) => acc + parseFloat(i.score_delta), 0);
+          s.score += totalDelta;
+        });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+
+    const diseases = scored.slice(0, 6).map(({ item, score }) => ({
+      ...item.toJSON(),
+      score: Number(score.toFixed(2))
+    }));
+
+    const questions = await Question.findAll({
+      where: { trigger_symptom_id: { [Op.in]: symptomIds } },
+      include: [{ model: QuestionOption, as: 'options' }]
+    });
+
+    const answered = responses.map(r => r.questionId);
+    const nextQuestions = questions.filter(q => !answered.includes(q.id));
+
+    res.json({ diseases, questions: nextQuestions });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur lors de la recherche interactive' });
   }
 });
 


### PR DESCRIPTION
## Summary
- extend backend to support interactive disease search using questions
- model new tables `questions`, `question_options`, `option_impacts` and `user_question_responses`
- expose a `/api/maladies/interactive` endpoint
- document the new route and models in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68586e7d0a1c8330b8022fea6ad18b1a