### PR TITLE
Add admin dashboard and question management

### DIFF
--- a/ade-backend/src/index.js
+++ b/ade-backend/src/index.js
@@ -23,6 +23,7 @@ const userRouter = require('./routes/user'); // route GET /api/users
 const checksRouter = require('./routes/checks');
 const patientRouter = require('./routes/patient');
 const pharmacyRouter = require('./routes/pharmacy');
+const adminRouter = require('./routes/admin');
 
 
 // 5. App Express
@@ -51,6 +52,7 @@ app.use('/api/users', userRouter);
 app.use('/api/checks', checksRouter);
 app.use('/api', patientRouter);
 app.use('/api', pharmacyRouter);
+app.use('/api/admin', adminRouter);
 
 // 9. Connexion à la BDD, synchronisation des modèles, puis démarrage du serveur
 (async () => {

--- a/ade-backend/src/middleware/admin.js
+++ b/ade-backend/src/middleware/admin.js
@@ -1,0 +1,6 @@
+module.exports = (req, res, next) => {
+  if (!req.user || req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Access denied' });
+  }
+  next();
+};

--- a/ade-backend/src/models/User.js
+++ b/ade-backend/src/models/User.js
@@ -2,7 +2,7 @@ module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define('User', {
     id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
     role: {
-      type: DataTypes.ENUM('patient','doctor','pharmacy','courier'),
+      type: DataTypes.ENUM('patient','doctor','pharmacy','courier','admin'),
       allowNull: false,
       defaultValue: 'patient'
     },

--- a/ade-backend/src/routes/admin.js
+++ b/ade-backend/src/routes/admin.js
@@ -1,0 +1,140 @@
+const express = require('express');
+const router = express.Router();
+const { Question, QuestionOption, OptionImpact, DiseasesList, Symptom } = require('../models');
+const auth = require('../middleware/auth');
+const adminOnly = require('../middleware/admin');
+
+router.use(auth, adminOnly);
+
+// GET /admin/questions?symptom=...
+router.get('/questions', async (req, res) => {
+  try {
+    const where = {};
+    if (req.query.symptom) {
+      const sym = await Symptom.findOne({ where: { name: req.query.symptom } });
+      if (sym) where.trigger_symptom_id = sym.id; else where.trigger_symptom_id = -1; // no results
+    }
+    const questions = await Question.findAll({
+      where,
+      include: [{
+        model: QuestionOption,
+        as: 'options',
+        include: [{ model: OptionImpact, as: 'impacts', include: [DiseasesList] }]
+      }]
+    });
+    res.json(questions);
+  } catch (err) {
+    console.error('[ADMIN][GET /questions]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// POST /admin/questions
+router.post('/questions', async (req, res) => {
+  try {
+    const { question_text, question_type, trigger_symptom_id } = req.body;
+    const q = await Question.create({ question_text, question_type, trigger_symptom_id });
+    res.status(201).json(q);
+  } catch (err) {
+    console.error('[ADMIN][POST /questions]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// PUT /admin/questions/:id
+router.put('/questions/:id', async (req, res) => {
+  try {
+    const q = await Question.findByPk(req.params.id);
+    if (!q) return res.status(404).json({ error: 'Not found' });
+    await q.update({ question_text: req.body.question_text, question_type: req.body.question_type, trigger_symptom_id: req.body.trigger_symptom_id });
+    res.json(q);
+  } catch (err) {
+    console.error('[ADMIN][PUT /questions/:id]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// DELETE /admin/questions/:id
+router.delete('/questions/:id', async (req, res) => {
+  try {
+    const q = await Question.findByPk(req.params.id);
+    if (!q) return res.status(404).json({ error: 'Not found' });
+    await q.destroy();
+    res.json({ message: 'deleted' });
+  } catch (err) {
+    console.error('[ADMIN][DELETE /questions/:id]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// OPTIONS CRUD
+router.post('/questions/:questionId/options', async (req, res) => {
+  try {
+    const opt = await QuestionOption.create({ question_id: req.params.questionId, option_label: req.body.option_label });
+    res.status(201).json(opt);
+  } catch (err) {
+    console.error('[ADMIN][POST option]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+router.put('/options/:id', async (req, res) => {
+  try {
+    const opt = await QuestionOption.findByPk(req.params.id);
+    if (!opt) return res.status(404).json({ error: 'Not found' });
+    await opt.update({ option_label: req.body.option_label });
+    res.json(opt);
+  } catch (err) {
+    console.error('[ADMIN][PUT option]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+router.delete('/options/:id', async (req, res) => {
+  try {
+    const opt = await QuestionOption.findByPk(req.params.id);
+    if (!opt) return res.status(404).json({ error: 'Not found' });
+    await opt.destroy();
+    res.json({ message: 'deleted' });
+  } catch (err) {
+    console.error('[ADMIN][DELETE option]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Impacts CRUD
+router.post('/options/:optionId/impacts', async (req, res) => {
+  try {
+    const impact = await OptionImpact.create({ option_id: req.params.optionId, disease_id: req.body.disease_id, score_delta: req.body.score_delta });
+    res.status(201).json(impact);
+  } catch (err) {
+    console.error('[ADMIN][POST impact]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+router.put('/impacts/:id', async (req, res) => {
+  try {
+    const impact = await OptionImpact.findByPk(req.params.id);
+    if (!impact) return res.status(404).json({ error: 'Not found' });
+    await impact.update({ disease_id: req.body.disease_id, score_delta: req.body.score_delta });
+    res.json(impact);
+  } catch (err) {
+    console.error('[ADMIN][PUT impact]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+router.delete('/impacts/:id', async (req, res) => {
+  try {
+    const impact = await OptionImpact.findByPk(req.params.id);
+    if (!impact) return res.status(404).json({ error: 'Not found' });
+    await impact.destroy();
+    res.json({ message: 'deleted' });
+  } catch (err) {
+    console.error('[ADMIN][DELETE impact]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/ade-frontend/src/App.jsx
+++ b/ade-frontend/src/App.jsx
@@ -15,6 +15,7 @@ import DoctorDashboard from './pages/DoctorDashboard.jsx';
 import PatientDashboard from './pages/PatientDashboard.jsx';
 import Pharmacie from './pages/Pharmacie.jsx';
 import PharmacyDashboard from './pages/PharmacyDashboard.jsx';
+import AdminDashboard from './pages/AdminDashboard.jsx';
 import './index.css';
 
 export default function App() {
@@ -38,6 +39,7 @@ export default function App() {
           <Route path="/patient" element={<PatientDashboard />} />
           <Route path="/pharmacy" element={<PharmacyDashboard />} />
           <Route path="/pharmacie" element={<Pharmacie />} />
+          <Route path="/admin" element={<AdminDashboard />} />
 
           {/* Catch-all pour URL inconnues */}
           <Route

--- a/ade-frontend/src/api/admin.js
+++ b/ade-frontend/src/api/admin.js
@@ -1,0 +1,14 @@
+import api from '../services/api';
+
+export const fetchQuestions = params => api.get('/admin/questions', { params });
+export const createQuestion = data => api.post('/admin/questions', data);
+export const updateQuestion = (id, data) => api.put(`/admin/questions/${id}`, data);
+export const deleteQuestion = id => api.delete(`/admin/questions/${id}`);
+
+export const addOption = (questionId, data) => api.post(`/admin/questions/${questionId}/options`, data);
+export const updateOption = (id, data) => api.put(`/admin/options/${id}`, data);
+export const deleteOption = id => api.delete(`/admin/options/${id}`);
+
+export const addImpact = (optionId, data) => api.post(`/admin/options/${optionId}/impacts`, data);
+export const updateImpact = (id, data) => api.put(`/admin/impacts/${id}`, data);
+export const deleteImpact = id => api.delete(`/admin/impacts/${id}`);

--- a/ade-frontend/src/components/Navbar.jsx
+++ b/ade-frontend/src/components/Navbar.jsx
@@ -57,7 +57,7 @@ export default function Navbar() {
     role === 'doctor' ? '/doctor'
     : role === 'pharmacy' ? '/pharmacy'
     : role === 'courier' ? '/courier'
-    : '/patient';
+    : role === 'admin' ? '/admin' : '/patient';
 
   const navigate = useNavigate();
 
@@ -78,6 +78,9 @@ export default function Navbar() {
         <NavLink to="/maladies" className="navbar__link">Diagnostic</NavLink>
         <NavLink to="/consultation" className="navbar__link">Consultation</NavLink>
         <NavLink to="/pharmacie" className="navbar__link">e-Pharmacie</NavLink>
+        {token && role === 'admin' && (
+          <NavLink to="/admin" className="navbar__link">Administration</NavLink>
+        )}
         {token && (
           <NavLink to={dashboardLink} className="navbar__link">Mon compte</NavLink>
         )}

--- a/ade-frontend/src/pages/AdminDashboard.css
+++ b/ade-frontend/src/pages/AdminDashboard.css
@@ -1,0 +1,21 @@
+.admin-dashboard {
+  margin-top: 2rem;
+}
+.question-form input,
+.question-form select {
+  margin-right: 0.5rem;
+}
+.question-list {
+  list-style: none;
+  padding: 0;
+}
+.question-item {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+.question-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/ade-frontend/src/pages/AdminDashboard.jsx
+++ b/ade-frontend/src/pages/AdminDashboard.jsx
@@ -1,0 +1,148 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import {
+  fetchQuestions,
+  createQuestion,
+  updateQuestion,
+  deleteQuestion,
+  addOption,
+  updateOption,
+  deleteOption,
+  addImpact,
+  updateImpact,
+  deleteImpact
+} from '../api/admin';
+import './AdminDashboard.css';
+
+export default function AdminDashboard() {
+  const { token, role } = useContext(AuthContext);
+  const [questions, setQuestions] = useState([]);
+  const [form, setForm] = useState({ question_text: '', question_type: 'yes_no', trigger_symptom_id: '' });
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState('');
+
+  const load = async () => {
+    try {
+      const { data } = await fetchQuestions(search ? { symptom: search } : {});
+      setQuestions(data);
+    } catch (err) {
+      console.error('fetch questions', err);
+      setError('Erreur de chargement');
+    }
+  };
+
+  useEffect(() => {
+    if (role === 'admin' && token) load();
+  }, [token, role]);
+
+  if (role !== 'admin') return <p>Access Denied</p>;
+
+  const handleChange = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const handleCreate = async e => {
+    e.preventDefault();
+    try {
+      await createQuestion(form);
+      setForm({ question_text: '', question_type: 'yes_no', trigger_symptom_id: '' });
+      load();
+    } catch(err) {
+      console.error('create question', err);
+      setError('Erreur création');
+    }
+  };
+
+  const handleAddOption = async (qid, label) => {
+    if (!label) return;
+    await addOption(qid, { option_label: label });
+    load();
+  };
+
+  const handleDeleteQuestion = async id => { await deleteQuestion(id); load(); };
+  const handleDeleteOption = async id => { await deleteOption(id); load(); };
+  const handleDeleteImpact = async id => { await deleteImpact(id); load(); };
+
+  const handleAddImpact = async (optId, disease_id, score_delta) => {
+    if (!disease_id) return;
+    await addImpact(optId, { disease_id, score_delta });
+    load();
+  };
+
+  return (
+    <div className="container admin-dashboard">
+      <h1>Administration</h1>
+      <form onSubmit={handleCreate} className="question-form">
+        <input name="question_text" placeholder="Texte" value={form.question_text} onChange={handleChange} required />
+        <select name="question_type" value={form.question_type} onChange={handleChange}>
+          <option value="yes_no">Oui/Non</option>
+          <option value="multiple_choice">Choix multiple</option>
+          <option value="number">Nombre</option>
+          <option value="scale">Echelle</option>
+        </select>
+        <input name="trigger_symptom_id" placeholder="Symptom ID" value={form.trigger_symptom_id} onChange={handleChange} />
+        <button type="submit">Créer</button>
+      </form>
+      {error && <p className="error">{error}</p>}
+
+      <div className="search-bar">
+        <input placeholder="Filtrer par symptôme" value={search} onChange={e=>setSearch(e.target.value)} />
+        <button onClick={load}>Rechercher</button>
+      </div>
+
+      <ul className="question-list">
+        {questions.map(q => (
+          <li key={q.id} className="question-item">
+            <div className="question-header">
+              <strong>#{q.id}</strong> {q.question_text}
+              <button onClick={() => handleDeleteQuestion(q.id)}>Supprimer</button>
+            </div>
+            <ul>
+              {q.options.map(o => (
+                <li key={o.id}>
+                  {o.option_label}
+                  <button onClick={() => handleDeleteOption(o.id)}>X</button>
+                  <ul>
+                    {o.impacts.map(im => (
+                      <li key={im.id}>
+                        Maladie {im.disease_id} : {im.score_delta}
+                        <button onClick={() => handleDeleteImpact(im.id)}>X</button>
+                      </li>
+                    ))}
+                    <li>
+                      <small>Ajouter impact :</small>
+                      <AddImpactForm optionId={o.id} onAdd={handleAddImpact} />
+                    </li>
+                  </ul>
+                </li>
+              ))}
+              <li>
+                <AddOptionForm questionId={q.id} onAdd={handleAddOption} />
+              </li>
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AddOptionForm({ questionId, onAdd }) {
+  const [label, setLabel] = useState('');
+  return (
+    <form onSubmit={e => { e.preventDefault(); onAdd(questionId, label); setLabel(''); }}>
+      <input value={label} onChange={e=>setLabel(e.target.value)} placeholder="Nouvelle option" />
+      <button type="submit">Ajouter</button>
+    </form>
+  );
+}
+
+function AddImpactForm({ optionId, onAdd }) {
+  const [diseaseId, setDiseaseId] = useState('');
+  const [delta, setDelta] = useState('');
+  return (
+    <form onSubmit={e => { e.preventDefault(); onAdd(optionId, diseaseId, delta); setDiseaseId(''); setDelta(''); }}>
+      <input value={diseaseId} onChange={e=>setDiseaseId(e.target.value)} placeholder="Disease ID" />
+      <input value={delta} onChange={e=>setDelta(e.target.value)} placeholder="Delta" />
+      <button type="submit">Ajouter</button>
+    </form>
+  );
+}

--- a/ade-frontend/src/pages/Login.jsx
+++ b/ade-frontend/src/pages/Login.jsx
@@ -28,10 +28,11 @@ export default function Login() {
     try {
       const { data } = await api.post('/auth/login', { email, password });
       login(data.token, data.role);
-      if (data.role === 'doctor')      navigate('/doctor');
-        else if (data.role === 'pharmacy') navigate('/pharmacy');
-        else if (data.role === 'courier')  navigate('/courier');
-        else                               navigate('/patient'); // patient par défaut       // <-- redirection vers la page Profil
+      if (data.role === 'admin')         navigate('/admin');
+        else if (data.role === 'doctor')      navigate('/doctor');
+        else if (data.role === 'pharmacy')    navigate('/pharmacy');
+        else if (data.role === 'courier')     navigate('/courier');
+        else                                  navigate('/patient'); // patient par défaut
     } catch (err) {
       console.error('Erreur login:', err);
       setError(err.response?.data?.error || 'Erreur de connexion');


### PR DESCRIPTION
## Summary
- add `admin` role to users
- create admin middleware and routes for managing questions, options and impacts
- expose new admin API on backend
- build minimal React admin dashboard UI
- show Administration link in navbar and redirect admin users on login

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858808c4550833090da1ecaf9f7db57