### PR TITLE
Implement symptom name autocomplete in admin dashboard

### DIFF
--- a/ade-frontend/src/pages/PharmacyDashboard.jsx
+++ b/ade-frontend/src/pages/PharmacyDashboard.jsx
@@ -7,10 +7,6 @@ import './PharmacyDashboard.css';
 export default function PharmacyDashboard() {
   const { token, logout } = useContext(AuthContext);
   const [pharmacy, setPharmacy] = useState(null);
-<<<<<<< HEAD
-=======
-  const [user, setUser] = useState(null);
->>>>>>> d8e7844f6d1cbbbfa1dae6024e3df08defe0809f
   const [form, setForm] = useState({ name: '', address: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -19,16 +15,6 @@ export default function PharmacyDashboard() {
     if (!token) return;
     const fetchData = async () => {
       try {
-<<<<<<< HEAD
-=======
-        const { data } = await api.get('/moncompte');
-        setUser(data);
-      } catch (err) {
-        console.error('Pharmacy dashboard user fetch error', err);
-        if (err.response?.status === 401) logout();
-      }
-      try {
->>>>>>> d8e7844f6d1cbbbfa1dae6024e3df08defe0809f
         const { data } = await api.get('/pharmacies/me');
         setPharmacy(data);
       } catch (err) {
@@ -117,8 +103,4 @@ export default function PharmacyDashboard() {
         </section>
     </div>
   );
-<<<<<<< HEAD
 }
-=======
-}
->>>>>>> d8e7844f6d1cbbbfa1dae6024e3df08defe0809f


### PR DESCRIPTION
## Summary
- enhance `/api/symptomes` route to optionally return IDs when `full=1`
- clean up merge leftovers in `PharmacyDashboard`
- allow admins to pick symptoms by name with suggestions and auto-fill the ID

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68588aadb4bc8330bad3954cd130aca7