### PR TITLE
Fix admin dashboard option retrieval

### DIFF
--- a/ade-frontend/src/api/admin.js
+++ b/ade-frontend/src/api/admin.js
@@ -1,5 +1,7 @@
 import api from '../services/api';
 
+export const fetchSymptoms = params => api.get('/admin/symptoms', { params });
+
 export const fetchQuestions = params => api.get('/admin/questions', { params });
 export const createQuestion = data => api.post('/admin/questions', data);
 export const updateQuestion = (id, data) => api.put(`/admin/questions/${id}`, data);
@@ -12,3 +14,8 @@ export const deleteOption = id => api.delete(`/admin/options/${id}`);
 export const addImpact = (optionId, data) => api.post(`/admin/options/${optionId}/impacts`, data);
 export const updateImpact = (id, data) => api.put(`/admin/impacts/${id}`, data);
 export const deleteImpact = id => api.delete(`/admin/impacts/${id}`);
+
+export const fetchOptions = symptomId =>
+  api.get(`/admin/options/${symptomId}`);
+
+export const fetchScores = symptomId => api.get(`/admin/scores/${symptomId}`);

--- a/ade-frontend/src/pages/AdminDashboard.jsx
+++ b/ade-frontend/src/pages/AdminDashboard.jsx
@@ -5,7 +5,7 @@ import { AuthContext } from '../context/AuthContext';
 import {
   fetchSymptoms,
   fetchQuestions,
-  fetchResponses,
+  fetchOptions,
   fetchScores
 } from '../api/admin'; // your admin-specific API methods
 import './AdminDashboard.css';
@@ -20,10 +20,10 @@ export default function AdminDashboard() {
   const perPage = 9;
 
   const [selectedSymptom, setSelectedSymptom] = useState(null);
-  const [viewType, setViewType] = useState('questions'); // 'questions' | 'responses' | 'scores'
+  const [viewType, setViewType] = useState('questions'); // 'questions' | 'options' | 'scores'
 
   const [questions, setQuestions] = useState([]);
-  const [responses, setResponses] = useState([]);
+  const [options, setOptions] = useState([]);
   const [scores, setScores] = useState([]);
 
   // --- Load Symptoms ---
@@ -44,9 +44,9 @@ export default function AdminDashboard() {
       if (viewType === 'questions') {
         const { data } = await fetchQuestions({ symptom: id });
         setQuestions(data);
-      } else if (viewType === 'responses') {
-        const { data } = await fetchResponses(id);
-        setResponses(data);
+      } else if (viewType === 'options') {
+        const { data } = await fetchOptions(id);
+        setOptions(data);
       } else if (viewType === 'scores') {
         const { data } = await fetchScores(id);
         setScores(data);
@@ -132,7 +132,7 @@ export default function AdminDashboard() {
                     onChange={(e) => setViewType(e.target.value)}
                   >
                     <option value="questions">Questions</option>
-                    <option value="responses">Réponses</option>
+                    <option value="options">Options</option>
                     <option value="scores">Score</option>
                   </select>
                 </div>
@@ -151,16 +151,16 @@ export default function AdminDashboard() {
                     </>
                   )}
 
-                  {viewType === 'responses' && (
+                  {viewType === 'options' && (
                     <>
-                      {responses.length > 0 ? (
+                      {options.length > 0 ? (
                         <ul>
-                          {responses.map((r) => (
-                            <li key={r.id}>{r.text}</li>
+                          {options.map((o) => (
+                            <li key={o.id}>{o.text}</li>
                           ))}
                         </ul>
                       ) : (
-                        <button className="add-btn">Ajouter une réponse</button>
+                        <button className="add-btn">Ajouter une option</button>
                       )}
                     </>
                   )}


### PR DESCRIPTION
## Summary
- update backend admin route to list question options by symptom
- expose `fetchOptions` helper instead of `fetchResponses`
- display options list in admin dashboard

## Testing
- `node -e "new Function(require('fs').readFileSync('ade-backend/src/routes/admin.js'))"`
- `node -e "new Function(require('fs').readFileSync('ade-frontend/src/api/admin.js'))"` *(fails: Cannot use import statement outside a module)*
- `node -e "new Function(require('fs').readFileSync('ade-frontend/src/pages/AdminDashboard.jsx'))"` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68599b678c9c83309b1268ac3b44e8bd