### PR TITLE
Add admin dashboard forms for questions options scores

### DIFF
--- a/ade-backend/src/routes/admin.js
+++ b/ade-backend/src/routes/admin.js
@@ -29,6 +29,25 @@ router.get('/symptoms', async (req, res) => {
   }
 });
 
+// GET /admin/symptoms/:id/diseases
+router.get('/symptoms/:id/diseases', async (req, res) => {
+  try {
+    const list = await DiseasesList.findAll({
+      include: [{
+        model: Symptom,
+        through: { attributes: [] },
+        where: { id: req.params.id }
+      }],
+      order: [['Nom', 'ASC']]
+    });
+    const mapped = list.map(d => ({ id: d.id, name: d.Nom }));
+    res.json(mapped);
+  } catch (err) {
+    console.error('[ADMIN][GET /symptoms/:id/diseases]', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
 // GET /admin/questions?symptom=...
 router.get('/questions', async (req, res) => {
   try {

--- a/ade-frontend/src/api/admin.js
+++ b/ade-frontend/src/api/admin.js
@@ -19,3 +19,6 @@ export const fetchOptions = symptomId =>
   api.get(`/admin/options/${symptomId}`);
 
 export const fetchScores = symptomId => api.get(`/admin/scores/${symptomId}`);
+
+export const fetchRelatedDiseases = symptomId =>
+  api.get(`/admin/symptoms/${symptomId}/diseases`);

--- a/ade-frontend/src/pages/AdminDashboard.css
+++ b/ade-frontend/src/pages/AdminDashboard.css
@@ -94,3 +94,10 @@
   border-radius: 4px;
   cursor: pointer;
 }
+
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- support listing diseases related to a symptom from backend
- fetch related diseases in the frontend API
- allow creating questions, options and scores from AdminDashboard
- show diseases list and simple forms
- minor styling for admin forms

## Testing
- `npm run lint` in `ade-frontend`
- `npm run lint` *(fails: missing script)* in `ade-backend`


------
https://chatgpt.com/codex/tasks/task_e_6859c925152c8330b20eb45141f9ba4c