### PR TITLE
Improve score and option cards

### DIFF
--- a/ade-backend/src/routes/admin.js
+++ b/ade-backend/src/routes/admin.js
@@ -124,12 +124,16 @@ router.get('/options/:symptomId', async (req, res) => {
         {
           model: Question,
           where: { trigger_symptom_id: symptomId },
-          attributes: []
+          attributes: ['question_text']
         }
       ],
       order: [['option_label', 'ASC']]
     });
-    const mapped = options.map(o => ({ id: o.id, text: o.option_label }));
+    const mapped = options.map(o => ({
+      id: o.id,
+      text: o.option_label,
+      question_text: o.Question ? o.Question.question_text : null
+    }));
     res.json(mapped);
   } catch (err) {
     console.error('[ADMIN][GET /options/:symptomId]', err);
@@ -153,6 +157,7 @@ router.get('/scores/:symptomId', async (req, res) => {
     const result = impacts.map(i => ({
       id: i.id,
       disease_name: i.DiseasesList ? i.DiseasesList.Nom : null,
+      option_text: i.QuestionOption ? i.QuestionOption.option_label : null,
       value: parseFloat(i.score_delta)
     }));
     res.json(result);

--- a/ade-frontend/src/pages/AdminDashboard.jsx
+++ b/ade-frontend/src/pages/AdminDashboard.jsx
@@ -269,7 +269,9 @@ export default function AdminDashboard() {
                       {options.length > 0 && (
                         <ul>
                           {options.map((o) => (
-                            <li key={o.id}>{o.text}</li>
+                            <li key={o.id}>
+                              <strong>{o.question_text}</strong> : {o.text}
+                            </li>
                           ))}
                         </ul>
                       )}
@@ -325,7 +327,7 @@ export default function AdminDashboard() {
                         <ul>
                           {scores.map((s) => (
                             <li key={s.id}>
-                              {s.disease_name} : {s.value}
+                              {s.disease_name} - {s.option_text} : {s.value}
                             </li>
                           ))}
                         </ul>
@@ -339,7 +341,9 @@ export default function AdminDashboard() {
                           >
                             <option value="">-- Option --</option>
                             {options.map(o => (
-                              <option key={o.id} value={o.id}>{o.text}</option>
+                              <option key={o.id} value={o.id}>
+                                {o.question_text ? `${o.question_text} - ${o.text}` : o.text}
+                              </option>
                             ))}
                           </select>
                           <select


### PR DESCRIPTION
## Summary
- enrich admin option API to return question text
- enrich admin score API to include option text
- show question with every option in admin dashboard
- display option text with each score in admin dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ac6f8dbc08330afaee61a79b0f5ce