### PR TITLE
Fix auth form autocomplete retention

### DIFF
--- a/ade-frontend/src/pages/Login.jsx
+++ b/ade-frontend/src/pages/Login.jsx
@@ -28,6 +28,8 @@ export default function Login() {
     try {
       const { data } = await api.post('/auth/login', { email, password });
       login(data.token, data.role);
+      setEmail('');
+      setPassword('');
       if (data.role === 'admin')         navigate('/admin');
         else if (data.role === 'doctor')      navigate('/doctor');
         else if (data.role === 'pharmacy')    navigate('/pharmacy');
@@ -49,6 +51,7 @@ export default function Login() {
     try {
       const { data } = await api.post('/auth/forgot', { email });
       setInfo(`Email envoyé ! Ouvre ce lien de preview : ${data.previewUrl}`);
+      setEmail('');
       setLoading(false);
     } catch (err) {
       setError(err.response?.data?.error || 'Erreur lors de la demande');
@@ -62,12 +65,13 @@ export default function Login() {
       {step === 'login' ? (
         <>
           <h1>Connexion</h1>
-          <form onSubmit={handleLogin} className="auth-form">
+          <form onSubmit={handleLogin} className="auth-form" autoComplete="off">
             <input
               type="email"
               placeholder="Email"
               value={email}
               onChange={e => setEmail(e.target.value)}
+              autoComplete="off"
               required
             />
             <input
@@ -75,6 +79,7 @@ export default function Login() {
               placeholder="Mot de passe"
               value={password}
               onChange={e => setPassword(e.target.value)}
+              autoComplete="off"
               required
             />
             {!loading && <button type="submit">Se connecter</button>}
@@ -90,12 +95,13 @@ export default function Login() {
       ) : (
         <>
           <h1>Mot de passe oublié</h1>
-          <form onSubmit={handleForgot} className="auth-form">
+          <form onSubmit={handleForgot} className="auth-form" autoComplete="off">
             <input
               type="email"
               placeholder="Votre email"
               value={email}
               onChange={e => setEmail(e.target.value)}
+              autoComplete="off"
               required
             />
             {!loading && <button type="submit">Envoyer le lien</button>}

--- a/ade-frontend/src/pages/Register.jsx
+++ b/ade-frontend/src/pages/Register.jsx
@@ -6,33 +6,35 @@ import { AuthContext } from "../context/AuthContext";
 import PasswordStrengthMeter from "../components/PasswordStrengthMeter";
 import MapPicker from "../components/MapPicker";
 
+const initialForm = {
+  email: "",
+  password: "",
+  confirmPassword: "",
+  role: "patient",
+  first_name: "",
+  last_name: "",
+  birthdate: "",
+  // doctor
+  speciality: "",
+  onmc: "",
+  workplace: "",
+  bio: "",
+  // pharmacy
+  name: "",
+  address: "",
+  latitude: "",
+  longitude: "",
+  // courier
+  vehicle_type: "motorbike",
+  plate_number: "",
+  driver_license: "",
+};
+
 export default function Register() {
   const { login } = useContext(AuthContext);
   const navigate = useNavigate();
   const [mapPos, setMapPos] = useState([48.8566, 2.3522]); // default Paris
-  const [form, setForm] = useState({
-    email: "",
-    password: "",
-    confirmPassword: "",
-    role: "patient",
-    first_name: "",
-    last_name: "",
-    birthdate: "",
-    // doctor
-    speciality: "",
-    onmc: "",
-    workplace: "",
-    bio: "",
-    // pharmacy
-    name: "",
-    address: "",
-    latitude: "",
-    longitude: "",
-    // courier
-    vehicle_type: "motorbike",
-    plate_number: "",
-    driver_license: "",
-  });
+  const [form, setForm] = useState(initialForm);
   const [error, setError] = useState("");
 
   useEffect(() => {
@@ -70,6 +72,7 @@ export default function Register() {
 
       // Si l'API renvoie un token, on connecte directement
       if (data.token) {
+        setForm(initialForm);
         login(data.token, data.role);
         if (data.role === 'doctor')      navigate('/doctor');
           else if (data.role === 'pharmacy') navigate('/pharmacy');
@@ -94,7 +97,7 @@ export default function Register() {
         </aside>
         <section className="register-page__form">
           <h1>Inscription</h1>
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit} autoComplete="off">
             <select
               name="role"
               value={form.role}
@@ -111,6 +114,7 @@ export default function Register() {
               placeholder="Email"
               value={form.email}
               onChange={handleChange}
+              autoComplete="off"
               required
             />
             <input
@@ -119,6 +123,7 @@ export default function Register() {
               placeholder="Nouveau mot de passe"
               value={form.password}
               onChange={handleChange}
+              autoComplete="new-password"
               required
             />
             <input
@@ -127,6 +132,7 @@ export default function Register() {
             placeholder="Confirmer mot de passe"
             value={form.confirmPassword}
             onChange={handleChange}
+            autoComplete="new-password"
             required
             />
             <PasswordStrengthMeter password={form.password} />


### PR DESCRIPTION
## Summary
- disable autocomplete on login and register forms
- clear login and register fields after successful submission

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c44576e508330a238cf220a226346