### PR TITLE
Implement interactive disease search flow

### DIFF
--- a/ade-frontend/src/api/diseases.js
+++ b/ade-frontend/src/api/diseases.js
@@ -1,0 +1,4 @@
+import api from '../services/api';
+
+export const interactiveSearch = (symptoms, responses = []) =>
+  api.post('/maladies/interactive', { symptoms, responses });

--- a/ade-frontend/src/components/QuestionCard.jsx
+++ b/ade-frontend/src/components/QuestionCard.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export default function QuestionCard({ question, onAnswer }) {
+  const [selected, setSelected] = useState(null);
+  if (!question) return null;
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (selected) {
+      onAnswer(selected);
+      setSelected(null);
+    }
+  };
+
+  return (
+    <div className="question-card">
+      <h2>{question.question_text}</h2>
+      <form onSubmit={handleSubmit}>
+        {question.options.map(opt => (
+          <label key={opt.id} className="question-option">
+            <input
+              type="radio"
+              name="option"
+              value={opt.id}
+              checked={selected === opt.id}
+              onChange={() => setSelected(opt.id)}
+            />
+            {opt.option_label}
+          </label>
+        ))}
+        <button type="submit" disabled={!selected}>Valider</button>
+      </form>
+    </div>
+  );
+}

--- a/ade-frontend/src/index.css
+++ b/ade-frontend/src/index.css
@@ -149,6 +149,26 @@ a:focus-visible {
   margin-bottom: 0.25rem;
 }
 
+/* Card for interactive questions */
+.question-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  max-width: 400px;
+}
+
+.question-card h2 {
+  margin-bottom: 1rem;
+}
+
+.question-option {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
 /*page inscription*/
 /* Conteneur en 2 colonnes */
 .register-page {


### PR DESCRIPTION
## Summary
- add QuestionCard component for multi-step search
- add interactiveSearch API helper
- integrate question flow in the Maladies page
- style question card in CSS

## Testing
- `npm install` in `ade-frontend`
- `npm run lint` in `ade-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685c4624d2c483309b51a4fb5ddf6ed9