### PR TITLE
Add question editing tools to admin dashboard

### DIFF
--- a/ade-frontend/src/pages/AdminDashboard.css
+++ b/ade-frontend/src/pages/AdminDashboard.css
@@ -144,3 +144,23 @@
 #disease-symptoms-card {
   width: 38%;
 }
+
+.edit-btn {
+  margin-left: 0.5rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.edit-container {
+  width: 100%;
+}
+
+.edit-score {
+  margin-left: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- allow admins to update questions, options and scores
- include edit controls in Symptoms section
- style new edit button and container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d8e51f8588330b254b56769bf8890